### PR TITLE
Fix metrics prometheus prefix name in metrics.md

### DIFF
--- a/guide/configuration.md
+++ b/guide/configuration.md
@@ -302,6 +302,8 @@ Enables and configures performance metrics exposure (e.g., Prometheus).
 - `METRICS_ENABLED` - Enable metrics
 - `METRICS_HOST` - Metrics server host
 - `METRICS_PORT` - Metrics server port
+- `METRICS_DRIVER` - Metrics driver
+- `METRICS_PROMETHEUS_PREFIX` - Metrics Prometheus prefix
 
 ### SSL Configuration
 

--- a/guide/configuration/metrics.md
+++ b/guide/configuration/metrics.md
@@ -68,7 +68,7 @@ These settings are applicable if `metrics.driver` is set to `"prometheus"`.
 
 ### `metrics.prometheus.prefix`
 * **JSON Key**: `prefix`
-* **Environment Variable**: `PROMETHEUS_METRICS_PREFIX`
+* **Environment Variable**: `METRICS_PROMETHEUS_PREFIX`
 * **Type**: `string`
 * **Description**: A prefix that will be added to all metric names exposed by Sockudo. Useful for namespacing in a shared Prometheus instance.
 * **Default Value**: `"sockudo_"`
@@ -94,7 +94,7 @@ METRICS_ENABLED=true
 METRICS_DRIVER=prometheus
 METRICS_HOST="0.0.0.0"
 METRICS_PORT=9601
-PROMETHEUS_METRICS_PREFIX="my_company_sockudo_"
+METRICS_PROMETHEUS_PREFIX="my_company_sockudo_"
 ```
 
 ## Available Metrics

--- a/guide/monitoring.md
+++ b/guide/monitoring.md
@@ -25,7 +25,7 @@ First, ensure that metrics are enabled in your Sockudo configuration:
 METRICS_ENABLED=true
 METRICS_HOST="0.0.0.0"
 METRICS_PORT=9601
-PROMETHEUS_METRICS_PREFIX="sockudo_"
+METRICS_PROMETHEUS_PREFIX="sockudo_"
 ```
 
 By default, metrics will be available at `http://<metrics_host>:<metrics_port>/metrics` (e.g., `http://localhost:9601/metrics`).


### PR DESCRIPTION
Corrects `METRICS_PROMETHEUS_PREFIX` env name in docs